### PR TITLE
moving posts to front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,6 @@ description: Semantic Visualization of Scientific Data
 # List of links in the navigation bar
 navbar-links:
   HOME: "/"
-  UPDATES: "posts"
   LAB: "https://brandeis-llc.github.io"
 
 # Image to show in the navigation bar - image must be a square (width = height)
@@ -167,7 +166,7 @@ markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/
 paginate: 5
-paginate_path: /posts/page:num/
+paginate_path: /page:num/
 
 kramdown:
   input: GFM

--- a/home.md
+++ b/home.md
@@ -1,8 +1,3 @@
----
-title: "SemViz"
-subtitle: Semantic Visualization of Scientific Data
-layout: page
----
 
 # Exploration and Discovery of the Covid-19 Literature through Semantic Visualization
 

--- a/index.html
+++ b/index.html
@@ -1,9 +1,12 @@
 ---
+title: "SemViz"
+subtitle: Semantic Visualization of Scientific Data
 layout: page
-title: What's New 
-subtitle: Recent updates from the SemViz team
 use-site-title: true
 ---
+
+{% capture home_md %}{% include_relative home.md %}{% endcapture %}
+{{ home_md | markdownify }}
 
 <div class="posts-list">
   {% for post in paginator.posts %}


### PR DESCRIPTION
also renamed former `index.md` to `home.md` due to name conflict. 